### PR TITLE
Fixed build error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ LDFLAGS = -lncurses
 tty-clock : ${SRC}
 
 	@echo "build ${SRC}"
-	@echo "CC ${CFLAGS} ${LDFLAGS} ${SRC}"
-	@${CC} ${CFLAGS} ${LDFLAGS} ${SRC} -o ${BIN}
+	${CC} ${CFLAGS} ${SRC} ${LDFLAGS} -o ${BIN}
 
 install : ${BIN}
 


### PR DESCRIPTION
Can't build tty-clock on Ubuntu 12.04:

```
$ git clone https://github.com/xorg62/tty-clock.git
$ cd tty-clock
$ make
build ttyclock.c
CC -Wall -g -lncurses ttyclock.c
/tmp/cc30ckIf.o: In function `init':
/usr/src/tty-clock/ttyclock.c:42: undefined reference to `initscr'
/usr/src/tty-clock/ttyclock.c:43: undefined reference to `cbreak'
/usr/src/tty-clock/ttyclock.c:44: undefined reference to `noecho'
...
/usr/src/tty-clock/ttyclock.c:328: undefined reference to `wgetch'
/usr/src/tty-clock/ttyclock.c:341: undefined reference to `LINES'
/usr/src/tty-clock/ttyclock.c:357: undefined reference to `COLS'
/usr/src/tty-clock/ttyclock.c:397: undefined reference to `init_pair'
/usr/src/tty-clock/ttyclock.c:398: undefined reference to `init_pair'
/tmp/cc30ckIf.o: In function `main':
/usr/src/tty-clock/ttyclock.c:493: undefined reference to `endwin'
collect2: ld returned 1 exit status
make: *** [tty-clock] Error 1
```

Moving the LDFLAGS behind the source file resolves the problem:

```
$ gcc -Wall -g ttyclock.c -lncurses -o tty-clock
$ ls -1 tty-clock 
tty-clock
```
