### PR TITLE
Add the f argument to optparse to avoid segfault.

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -465,7 +465,7 @@ main(int argc, char **argv)
      /* Default blink */
      ttyclock->option.blink = False;
 
-     while ((c = getopt(argc, argv, "utvsrcihfDBd:C:")) != -1)
+     while ((c = getopt(argc, argv, "utvsrcihf:DBd:C:")) != -1)
      {
           switch(c)
           {


### PR DESCRIPTION
 Otherwise optarg is set to 0, and we segfault when we
 try to strcpy it.
