### PR TITLE
Allow C and LD flags to be overwritten.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,12 @@ INSTALLPATH = ${DESTDIR}${PREFIX}/bin
 MANPATH = ${DESTDIR}${PREFIX}/share/man/man1
 
 ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
-	CFLAGS = -Wall -g -I $$(ncurses5-config --includedir)
-	LDFLAGS = -L $$(ncurses5-config --libdir) $$(ncursesw5-config --libs)
+	CFLAGS ?= -Wall -g -I $$(ncurses5-config --includedir)
+	LDFLAGS ?= -L $$(ncurses5-config --libdir) $$(ncursesw5-config --libs)
 else ifeq ($(shell sh -c 'which ncursesw5-config>/dev/null 2>/dev/null && echo y'), y)
-		CFLAGS = -Wall -g -I $$(ncursesw5-config --includedir)
-		LDFLAGS = -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
+		CFLAGS ?= -Wall -g -I $$(ncursesw5-config --includedir)
+		LDFLAGS ?= -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
 endif
-
-
-
 
 tty-clock : ${SRC}
 


### PR DESCRIPTION
This is useful for build on systems like bitrig and openbsd.
This change should be harmless for current builds but is helpful for adding it to bitrig ports.