### PR TITLE
Blink with changing color n times every hour

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,4 @@ usage : tty-clock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdel
     -B            Enable blinking colon                          
     -d delay      Set the delay between two redraws of the clock. Default 1s. 
     -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.
+    -l n	  Blink with changing color n times every hour.

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -686,6 +686,7 @@ main(int argc, char **argv)
 	       break;
 	  case 'l':
 	       ttyclock->option.colorblink = atoi(optarg);
+	       break;
           }
      }
 

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -292,6 +292,26 @@ draw_clock(void)
           draw_number(ttyclock->date.second[1], 1, 46);
      }
 
+     /* Blink with chaniging color every hour */
+     if(ttyclock->option.colorblink){
+          static int old_color = -1;
+	  int blink_times = ttyclock->option.colorblink;
+
+	  if(ttyclock->tm->tm_min == 0 && ttyclock->tm->tm_sec%2 == 0 && ttyclock->tm->tm_sec < blink_times * 2){
+	       int new_color = (ttyclock->option.color + 1) % 8;
+
+	       old_color = ttyclock->option.color;
+	       ttyclock->option.color = new_color;
+	       init_pair(1, ttyclock->bg, new_color);
+	       init_pair(2, new_color, ttyclock->bg);
+	  }
+	  else if(ttyclock->tm->tm_min == 0 && ttyclock->tm->tm_sec%2 == 1 && ttyclock->tm->tm_sec < blink_times * 2 && old_color != -1){
+	       ttyclock->option.color = old_color;
+	       init_pair(1, ttyclock->bg, old_color);
+	       init_pair(2, old_color, ttyclock->bg);
+	  }
+     }
+
      return;
 }
 
@@ -559,10 +579,11 @@ main(int argc, char **argv)
      ttyclock->option.delay = 1; /* 1FPS */
      ttyclock->option.nsdelay = 0; /* -0FPS */
      ttyclock->option.blink = False;
+     ttyclock->option.colorblink = 0;
 
      atexit(cleanup);
 
-     while ((c = getopt(argc, argv, "iuvsScbtrhBxnDC:f:d:T:a:")) != -1)
+     while ((c = getopt(argc, argv, "iuvsScbtrhBxnDC:f:d:T:a:l:")) != -1)
      {
           switch(c)
           {
@@ -587,7 +608,8 @@ main(int argc, char **argv)
                       "    -D            Hide date                                      \n"
                       "    -B            Enable blinking colon                          \n"
                       "    -d delay      Set the delay between two redraws of the clock. Default 1s. \n"
-                      "    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.\n");
+                      "    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.\n"
+		      "    -l n          Blink with changing color n times every hour.\n");
                exit(EXIT_SUCCESS);
                break;
           case 'i':
@@ -662,6 +684,8 @@ main(int argc, char **argv)
 	  case 'n':
 	       ttyclock->option.noquit = True;
 	       break;
+	  case 'l':
+	       ttyclock->option.colorblink = atoi(optarg);
           }
      }
 

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -83,6 +83,7 @@ typedef struct
           long delay;
           Bool blink;
           long nsdelay;
+          int colorblink;
      } option;
 
      /* Clock geometry */


### PR DESCRIPTION
-l option with one integer parameter n is added.

When this option is specified, the clock blinks by changing its color n times every hour.
For example, the color of 'tty-color -C 3 -l 2 -s' is changed as follows:
 10:00:00 // yellow (-C 3) 
 10:00:01 // blue (blinking starts)
 10:00:02 // yellow
 10:00:03 // blue
 10:00:04 // yellow (blinking finishes)
 10:00:05 // yellow
