### PR TITLE
allow supplying extra flags w/o erasing defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,18 @@
 #See clock.c for the license detail.
 
 SRC = ttyclock.c
-CC ?= gcc
+CC += gcc
 BIN = tty-clock
-PREFIX ?= /usr/local
+PREFIX += /usr/local
 INSTALLPATH = ${DESTDIR}${PREFIX}/bin
 MANPATH = ${DESTDIR}${PREFIX}/share/man/man1
 
 ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
-	CFLAGS ?= -Wall -g -I $$(ncurses5-config --includedir)
-	LDFLAGS ?= -L $$(ncurses5-config --libdir) $$(ncursesw5-config --libs)
+	CFLAGS += -Wall -g -I $$(ncurses5-config --includedir)
+	LDFLAGS += -L $$(ncurses5-config --libdir) $$(ncursesw5-config --libs)
 else ifeq ($(shell sh -c 'which ncursesw5-config>/dev/null 2>/dev/null && echo y'), y)
-		CFLAGS ?= -Wall -g -I $$(ncursesw5-config --includedir)
-		LDFLAGS ?= -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
+		CFLAGS += -Wall -g -I $$(ncursesw5-config --includedir)
+		LDFLAGS += -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
 endif
 
 tty-clock : ${SRC}


### PR DESCRIPTION
Here, `value` will be replaced if environment contains a variable of the same name :

```
VAR ?= value
```

But here, `value` will be appended to the environment variable :

```
VAR += value
```

Useful on systems which defines default `CFLAGS` and `LDFLAGS` globally.
