### PR TITLE
New option to use all color successively

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,10 @@
-usage : tty-clock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdelay] [-T tty] 
+usage : tty-clock [-iuvsScbtrahDBxnA] [-C [0-7]] [-f format] [-d delay] [-a nsdelay] [-T tty] 
     -s            Show seconds                                   
     -S            Screensaver mode                               
     -x            Show box                                       
     -c            Set the clock at the center of the terminal    
     -C [0-7]      Set the clock color                            
+    -A            Cange color successively every second
     -b            Use bold colors                                
     -t            Set the hour in 12h format                     
     -u            Use UTC time                                   

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -83,6 +83,7 @@ typedef struct
           long delay;
           Bool blink;
           long nsdelay;
+          Bool allcolors;
      } option;
 
      /* Clock geometry */


### PR DESCRIPTION
Using option -A all color are used successively.

While it's running 'a' and 'A' allows to start the loop.

If a key to set a color is used (1, 2, etc.) the loop stops.
