### PR TITLE
Make makefile OSX compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,17 @@ PREFIX ?= /usr/local
 INSTALLPATH = ${DESTDIR}${PREFIX}/bin
 MANPATH = ${DESTDIR}${PREFIX}/share/man/man1
 
-ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
+ifeq ($(shell sh -c 'which ncurses5-config&>/dev/null; $?'), 0)
 	CFLAGS ?= -Wall -g -I $$(ncurses5-config --includedir)
 	LDFLAGS ?= -L $$(ncurses5-config --libdir) $$(ncursesw5-config --libs)
-else ifeq ($(shell sh -c 'which ncursesw5-config>/dev/null 2>/dev/null && echo y'), y)
-		CFLAGS ?= -Wall -g -I $$(ncursesw5-config --includedir)
-		LDFLAGS ?= -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
+else ifeq ($(shell sh -c 'which ncursesw5-config&>/dev/null; $?'), 0)
+	CFLAGS ?= -Wall -g -I $$(ncursesw5-config --includedir)
+	LDFLAGS ?= -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
+else ifeq ($(shell sh -c 'brew ls --versions ncurses'), ncurses 6.0)
+	CFLAGS ?= -Wall -g -D_DARWIN_C_SOURCE -I/usr/local/Cellar/ncurses/6.0/include
+	LDFLAGS ?= -L/usr/local/Cellar/ncurses/6.0/lib -lncursesw
+else
+$(error Your build environment is not supported)
 endif
 
 tty-clock : ${SRC}


### PR DESCRIPTION
This PR fixes issue #27.

It introduces a few things :
- An expanded conditional logic check for original clauses as well as a failure clause
- A more idiomatic syntax change based on explicit exit code check instead of echoing on success and checking said echo
- An additional check with Homebrew on OS X

The way the failure clause may break the ability to pass LDFLAGS and CFLAGS directly from bash with command line arguments.
