### PR TITLE
do not silence compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,8 @@ endif
 
 tty-clock : ${SRC}
 
-	@echo "build ${SRC}"
-	@echo "CC ${CFLAGS} ${LDFLAGS} ${SRC}"
-	@${CC} ${CFLAGS} ${SRC} -o ${BIN} ${LDFLAGS}
+	@echo "building ${SRC}"
+	${CC} ${CFLAGS} ${SRC} -o ${BIN} ${LDFLAGS}
 
 install : ${BIN}
 


### PR DESCRIPTION
this creates warnings in Debian, as there are checks to see if we use proper hardening flags, for example.

besides, we *almost* show all the tags in the compile rule, might as well not silence it