### PR TITLE
set time structure at the right moment

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -182,11 +182,11 @@ update_hour(void)
      int ihour;
      char tmpstr[128];
 
+     ttyclock->lt = time(NULL);
      ttyclock->tm = localtime(&(ttyclock->lt));
      if(ttyclock->option.utc) {
          ttyclock->tm = gmtime(&(ttyclock->lt));
      }
-     ttyclock->lt = time(NULL);
 
      ihour = ttyclock->tm->tm_hour;
 


### PR DESCRIPTION
the way this was working before, we would populate the ttyclock->lt
field *after* fetching the ttyclock->tm structure, which means that
would get the `localtime` of the *previous* iteration. this created a
one second delay in the clock display that was, I believe,
unintentional. this accounts for part of the 2s delay when compared to
other clocks like vtclock or xclock.

Closes: #40