### PR TITLE
another shot at fixing buildchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ INSTALLPATH = ${DESTDIR}${PREFIX}/bin
 MANPATH = ${DESTDIR}${PREFIX}/share/man/man1
 
 ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
-	CFLAGS ?= -Wall -g -I $$(ncurses5-config --includedir)
-	LDFLAGS ?= -L $$(ncurses5-config --libdir) $$(ncursesw5-config --libs)
+	CFLAGS ?= -Wall -g $$(ncurses5-config --cflags)
+	LDFLAGS ?= $$(ncurses5-config --libs)
 else ifeq ($(shell sh -c 'which ncursesw5-config>/dev/null 2>/dev/null && echo y'), y)
-		CFLAGS ?= -Wall -g -I $$(ncursesw5-config --includedir)
-		LDFLAGS ?= -L $$(ncursesw5-config --libdir) $$(ncursesw5-config --libs)
+		CFLAGS ?= -Wall -g $$(ncursesw5-config --cflags)
+		LDFLAGS ?= $$(ncursesw5-config --libs)
 else
-	CFLAGS ?= -Wall -g $((pkg-config --cflags ncurses))
-	LDFLAGS ?= $$(pkg-config --libs ncurses))
+	CFLAGS ?= -Wall -g $$(pkg-config --cflags ncurses)
+	LDFLAGS ?= $$(pkg-config --libs ncurses)
 endif
 
 tty-clock : ${SRC}


### PR DESCRIPTION
previous Makefile changes didn't actually work for pkg-config. they
were taken from the Debian package, which operated differently.

furthermore, the ncurses5-config lines were incorrect: they were using
both ncursesw and ncurses and would fail if --libdir was
empty. instead, we use the more proper --cflags and --libs that all do
the right thing.

this should, arguably, only be done with pkg-config, but i didn't want
to introduce an additional dependency.

See: #38