### PR TITLE
Added 'concice' option

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,4 @@ usage : tty-clock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdel
     -B            Enable blinking colon
     -d delay      Set the delay between two redraws of the clock. Default 1s.
     -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.
+    -m            Disable margin, removing unused space around the clock.

--- a/tty-clock.1
+++ b/tty-clock.1
@@ -47,6 +47,9 @@ Switch time output to the 12\-hour format.
 .TP
 Q
 Quit.
+.TP
+M
+Toggles margin around the clock.
 .SH "OPTIONS"
 .LP
 .TP
@@ -110,6 +113,9 @@ Set the delay (in seconds) between two redraws of the clock. Default 1s.
 .TP
 \fB\-a\fR \fInsdelay\fR
 Additional delay (in nanoseconds) between two redraws of the clock. Default 0ns.
+.TP
+\fB\-m\fR
+Disable margin, removing unused space around the clock.
 .SH "EXAMPLES"
 .LP
 To invoke

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -85,6 +85,7 @@ typedef struct
           long delay;
           bool blink;
           long nsdelay;
+          bool nomargin;
      } option;
 
      /* Clock geometry */


### PR DESCRIPTION
Specifying -m option or clicking m on a keyboard during execution
gets rid of all unused space and makes the clock be as close to top left corner as possible.
Useful if you want to have the clock in the smallest terminal space possible.

Works (doesn't break) with border/box functionality (Enabling box negates this feature).

Without the option (red marks unused space):
![before](https://user-images.githubusercontent.com/11395615/28249290-0ec182f2-6a53-11e7-816a-f423734a75e0.png)


With the option:
![after](https://user-images.githubusercontent.com/11395615/28249253-650e4bc8-6a52-11e7-8528-62432bb6ac5f.png)
