### PR TITLE
Do not display date box when '-D' flag is provided

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -118,7 +118,7 @@ init(void)
                                 ttyclock->geo.x + ttyclock->geo.h - 1,
                                 ttyclock->geo.y + (ttyclock->geo.w / 2) -
                                 (strlen(ttyclock->date.datestr) / 2) - 1);
-     if(ttyclock->option.box) {
+     if(ttyclock->option.box && ttyclock->option.date) {
           box(ttyclock->datewin, 0, 0);
      }
      clearok(ttyclock->datewin, True);


### PR DESCRIPTION
This is a fix for the case when all `-x`, `-D` and `-c` are passed:

![shot-2017-10-31_155033](https://user-images.githubusercontent.com/8810597/32246651-07f57d78-be56-11e7-922d-9d2746c4ddbb.png)

So we draw the box only if `option.date` is `True`.