### PR TITLE
Clock position

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,4 @@ usage : tty-clock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdel
     -B            Enable blinking colon
     -d delay      Set the delay between two redraws of the clock. Default 1s.
     -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.
+    -p [1-9]      Position of clock in terminal: 1-9 starting top-left and ending bottom-right.

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -45,6 +45,7 @@
 #include <ncurses.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <wchar.h>
 
 /* Macro */
 #define NORMFRAMEW 35
@@ -84,6 +85,7 @@ typedef struct
           long delay;
           Bool blink;
           long nsdelay;
+          int position;
      } option;
 
      /* Clock geometry */
@@ -125,6 +127,7 @@ void set_second(void);
 void set_center(Bool b);
 void set_box(Bool b);
 void key_event(void);
+void set_position(int p);
 
 /* Global variable */
 ttyclock_t *ttyclock;


### PR DESCRIPTION
Added -p [1-9] switch for clock position. (I went with 0-9 initially but since the keys are in 1-9 order it seemed more logical).
Added keys for shift + numbers - !"#$%^&&*( to set postition on-the-fly.
Added support for GB keyboards using £ instead of # (wchar.h).