### PR TITLE
Some fixes for cross-compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@
 
 SRC = ttyclock.c
 CC ?= gcc
-BIN = tty-clock
+BIN ?= tty-clock
 PREFIX ?= /usr/local
-INSTALLPATH = ${DESTDIR}${PREFIX}/bin
-MANPATH = ${DESTDIR}${PREFIX}/share/man/man1
+INSTALLPATH ?= ${DESTDIR}${PREFIX}/bin
+MANPATH ?= ${DESTDIR}${PREFIX}/share/man/man1
 
 ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
 	CFLAGS += -Wall -g $$(ncurses5-config --cflags)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ PREFIX ?= /usr/local
 INSTALLPATH ?= ${DESTDIR}${PREFIX}/bin
 MANPATH ?= ${DESTDIR}${PREFIX}/share/man/man1
 
-ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
+ifeq ($(shell sh -c 'which ncurses6-config>/dev/null 2>/dev/null && echo y'), y)
+	CFLAGS += -Wall -g $$(ncurses6-config --cflags)
+	LDFLAGS += $$(ncurses6-config --libs)
+else ifeq ($(shell sh -c 'which ncursesw6-config>/dev/null 2>/dev/null && echo y'), y)
+		CFLAGS += -Wall -g $$(ncursesw6-config --cflags)
+		LDFLAGS += $$(ncursesw6-config --libs)
+else ifeq ($(shell sh -c 'which ncurses5-config>/dev/null 2>/dev/null && echo y'), y)
 	CFLAGS += -Wall -g $$(ncurses5-config --cflags)
 	LDFLAGS += $$(ncurses5-config --libs)
 else ifeq ($(shell sh -c 'which ncursesw5-config>/dev/null 2>/dev/null && echo y'), y)


### PR DESCRIPTION
This makes it easier to cross-compile on atari for example, with:

make CC=m68k-atari-mint-gcc BIN=ttyclock.prg

Other platforms, like Haiku, would also need to override the install paths anyway.