### PR TITLE
React to keyboard input without delay

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -421,6 +421,10 @@ key_event(void)
 
      struct timespec length = { ttyclock.option.delay, ttyclock.option.nsdelay };
      
+     fd_set rfds;
+     FD_ZERO(&rfds);
+     FD_SET(STDIN_FILENO, &rfds);
+
      if (ttyclock.option.screensaver)
      {
           c = wgetch(stdscr);
@@ -518,16 +522,16 @@ key_event(void)
           set_box(!ttyclock.option.box);
           break;
 
-     default:
-          nanosleep(&length, NULL);
-          for(i = 0; i < 8; ++i)
-               if(c == (i + '0'))
-               {
-                    ttyclock.option.color = i;
-                    init_pair(1, ttyclock.bg, i);
-                    init_pair(2, i, ttyclock.bg);
-               }
+     case '0': case '1': case '2': case '3':
+     case '4': case '5': case '6': case '7':
+          i = c - '0';
+          ttyclock.option.color = i;
+          init_pair(1, ttyclock.bg, i);
+          init_pair(2, i, ttyclock.bg);
           break;
+
+     default:
+          pselect(1, &rfds, NULL, NULL, &length, NULL);
      }
 
      return;

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -40,6 +40,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>


### PR DESCRIPTION
Currently, the input is processed only once a second (or once every $whatever_is_configured_as_delay). This is mildly infuriating.

With this PR, the input is processed immediately.

(As an unwanted side effect, if rebounding is enabled, pressing any key will now trigger premature clock move. I don't think it's a big deal. I hope to fix this buglet in another PR.)