### PR TITLE
Timer/countdown, a few fixes, some cleanup (manpage, option orders)

### DIFF
--- a/README
+++ b/README
@@ -1,20 +1,39 @@
-usage : tty-clock [-iuvsScbtrahDBxn] [-C [0-7]] [-f format] [-d delay] [-a nsdelay] [-T tty]
-    -s            Show seconds
-    -S            Screensaver mode
-    -x            Show box
-    -c            Set the clock at the center of the terminal
-    -C [0-7]      Set the clock color
-    -b            Use bold colors
-    -t            Set the hour in 12h format
-    -u            Use UTC time
-    -T tty        Display the clock on the specified terminal
-    -r            Do rebound the clock
-    -f format     Set the date format
-    -n            Don't quit on keypress
-    -v            Show tty-clock version
-    -i            Show some info about tty-clock
-    -h            Show this page
-    -D            Hide date
-    -B            Enable blinking colon
-    -d delay      Set the delay between two redraws of the clock. Default 1s.
-    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.
+tty-clock displays a simple digital clock, timer or countdown on the terminal.
+Invoked without options it will display the clock on the upper left corner of the screen on the terminal it was executed from.
+
+usage : tty-clock [-hvisHDtucrbxBeSn] [-f format] [-d delay] [-a nsdelay] [-C [0-7]] [-p duration] [-T tty]
+    -h            Show this page                                                   
+    -v            Show tty-clock version                                           
+    -i            Show some info about tty-clock                                   
+    -s            Show seconds                                                     
+    -H            Hide hour                                                        
+    -D            Hide date                                                        
+    -t            Set the hour in 12h format                                       
+    -u            Use UTC time                                                     
+    -f format     Set the date format                                              
+    -c            Set the clock at the center of the terminal                      
+    -r            Do rebound the clock                                             
+    -d delay      Set the delay between two redraws of the clock. Default 1s       
+    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns 
+    -C [0-7]      Set the clock color                                              
+    -B            Enable blinking colon                                            
+    -x            Show box                                                         
+    -b            Use bold colors                                                  
+    -e            Display elapsed time, not current time                           
+    -p duration   Set count down duration in seconds. Exit when done               
+    -S            Screensaver mode                                                 
+    -n            Don't quit on keypress                                           
+    -T tty        Display the clock on the specified terminal 
+
+To invoke tty-clock in screensaver mode with the clock display set to rebound and the update delay set to 1/10th of a second (10 FPS):
+
+  $ tty-clock -Sra 100000000 -d 0
+
+Exit after 30 minute have elapsed, showing hours and minutes centered in the window.
+
+  $ tty-clock -p 1800 -e -c
+
+Show a 1 minute and 10 seconds countdown in a box then exit. Hours are hidden, seconds are shown.
+
+  $ tty-clock -p 70 -x -Hs
+

--- a/tty-clock.1
+++ b/tty-clock.1
@@ -1,6 +1,7 @@
-.\" This manpage was written by Carla Valenti <valenti.karla@gmail.com>
-.\" and Christian Giessen <cgie@informatik.uni-kiel.de> for tty-clock.
-.\" In details the command line options displayed by tty-clock -h as
+.\" This manpage was written by Carla Valenti <valenti.karla@gmail.com>,
+.\" Christian Giessen <cgie@informatik.uni-kiel.de> and Jeremie Francois
+.\" <jeremie@tecrd.com> for tty-clock.
+.\" It details the command line options displayed by tty-clock -h as
 .\" well as the keyboard commands.
 .TH "TTY-CLOCK" "1" "October 2013" "" "User Commands"
 .SH "NAME"
@@ -8,10 +9,10 @@
 tty\-clock \- a terminal digital clock
 .SH "SYNOPSIS"
 .LP
-\fBtty\-clock [\-iuvsScbtrahDBxn] [\-C [\fI0\-7\fB]] [\-f \fIformat\fB] [\-d \fIdelay\fB] [\-a \fInsdelay\fB] \fB[\-T \fItty\fB]\fR
+\fBtty\-clock [\-hvisHDtucrbxBeSn] [\-f \fIformat\fB]  [\-d \fIdelay\fB] [\-a \fInsdelay\fB] [\-C [\fI0\-7\fB]] [\-p \fIduration\fB] \fB[\-T \fItty\fB]\fR
 .SH "DESCRIPTION"
 .LP
-\fItty\-clock\fR displays a simple digital clock on the terminal. Invoked without options
+\fItty\-clock\fR displays a simple digital clock, timer or countdown on the terminal. Invoked without options
 it will display the clock on the upper left corner of the screen on the terminal it was
 executed from.
 .SH "COMMANDS"
@@ -19,76 +20,54 @@ executed from.
 \fItty\-clock\fR accepts a number of runtime keyboard commands, upper and lower case characters are
 treated identically.
 .TP
+S
+Toggle display of seconds. Default is hidden.
+.TP
+M
+Toggle display of hours. Default is visible.
+.TP
+D
+Toggle display of date. Default is visible unless \fB-e\fR or \fB-p\fR were used ( or countdown modes).
+.TP
+T
+Toggle between 12\-hour and 24\-hour clock format. Default is 24\-hour mode.
+.TP
+C
+Toggle the clock's position to \fBcentered\fR. When set the movement commands are disabled.
+.TP
+R
+Toggle to screensaver-like animated \fBrebound\fR along the edges of the terminal.
+.TP
 K,J,H,L
 vi\-style movement commands to set the position of the displayed clock.
-These commands have no effect when the \fBcentered\fR option is set.
+These commands have no effect when the \fBcentered\fR or \fBrebound\fR option is set.
 .TP
 [0\-7]
 Select a different color for displaying the clock.
 .TP
 B
-Toggles between bold and normal colors.
+Toggle between bold and normal colors.
 .TP
 X
-Toggles displaying a box around the clock. This option is disabled by default.
+Toggle display of boxes around the time and date. Default is none.
 .TP
-C
-Toggle the clock's position to \fBcentered\fR.
-When set the movement commands are disabled.
+E
+Toogle elapsed time mode. Default is either absolute time, or remaning time if \fB-p\fR was used.
 .TP
-R
-Set the clock to \fBrebound\fR along the edges of the terminal.
 .TP
-S
-Display seconds.
+<space>
+Pause and resume clock, timer or countdown.
 .TP
-T
-Switch time output to the 12\-hour format.
+Z
+Restart the timer or countdown (see \fB-p\fR below). This command has no effect on regular time display.
 .TP
 Q
 Quit.
 .SH "OPTIONS"
 .LP
 .TP
-\fB\-s\fR
-Show seconds.
-.TP
-\fB\-S\fR
-Screensaver mode. tty\-clock terminates when any key is pressed.
-.TP
-\fB\-x\fR
-Show box.
-.TP
-\fB\-c\fR
-Set the clock at the center of the terminal.
-.TP
-\fB\-C\fR \fI[0\-7]\fR
-Set the clock color.
-.TP
-\fB\-b\fR
-Use bold colors.
-.TP
-\fB\-t\fR
-Set the hour in 12h format.
-.TP
-\fB\-u\fR
-Use UTC time.
-.TP
-\fB\-T\fR \fItty\fR
-Display the clock on the given \fItty\fR. \fItty\fR must be
-a valid character device to which the user has rw access permissions.
-(See \fBEXAMPLES\fR)
-.TP
-\fB\-r\fR
-Do rebound the clock.
-.TP
-\fB\-f\fR \fIformat\fR
-Set the date format as described in \fBstrftime(3)\fR.
-.TP
-\fB\-n\fR
-Do not quit the program when the Q key is pressed (or when any
-key is pressed while in \fBScreensaver\fR mode). A signal must
-be sent to \fItty\-clock\fR in order to terminate its execution. (See \fBEXAMPLES\fR)
+\fB\-h\fR
+Show usage information.
 .TP
 \fB\-v\fR
 Show tty\-clock version.
@@ -96,20 +75,66 @@ Show tty\-clock version.
 \fB\-i\fR
 Show some info about tty\-clock.
 .TP
-\fB\-h\fR
-Show usage information.
+\fB\-s\fR
+Show seconds.
+.TP
+\fB\-H\fR
+Hide hour.
 .TP
 \fB\-D\fR
-Hide the date.
+Hide date.
 .TP
-\fB\-B\fR
-Enable blinking colon.
+\fB\-t\fR
+Set the hour in 12h format.
+.TP
+\fB\-u\fR
+Use UTC time.
+.TP
+\fB\-f\fR \fIformat\fR
+Set the date format as described in \fBstrftime(3)\fR.
+.TP
+\fB\-c\fR
+Set the clock at the center of the terminal.
+.TP
+\fB\-r\fR
+Bounce the clock around the screen.
 .TP
 \fB\-d\fR \fIdelay\fR
 Set the delay (in seconds) between two redraws of the clock. Default 1s.
 .TP
 \fB\-a\fR \fInsdelay\fR
 Additional delay (in nanoseconds) between two redraws of the clock. Default 0ns.
+.TP
+\fB\-C\fR \fI[0\-7]\fR
+Set the clock color.
+.TP
+\fB\-b\fR
+Use bold colors.
+.TP
+\fB\-x\fR
+Draw boxes around clock and date.
+.TP
+\fB\-B\fR
+Blink the colons, unless the clock is paused (see \fBCOMMANDS\fR).
+.TP
+\fB\-e\fR
+Show elapsed time instead of time of day. Date will be hidden.
+.TP
+\fB\-p\fR \fIduration\fR
+Switch to countdown mode or to timer mode if \fB\-e\fR is also specified.  Date will be hidden.
+.TP
+\fB\-S\fR
+Screensaver mode. tty\-clock terminates when any key is pressed.
+.TP
+\fB\-n\fR
+Do not quit the program when the Q key is pressed (or when any
+key is pressed while in \fBScreensaver\fR mode). A signal must
+be sent to \fItty\-clock\fR in order to terminate its execution. (See \fBEXAMPLES\fR)
+.TP
+\fB\-T\fR \fItty\fR
+Display the clock on the given \fItty\fR. \fItty\fR must be
+a valid character device to which the user has rw access permissions.
+(See \fBEXAMPLES\fR)
 .SH "EXAMPLES"
 .LP
 To invoke
@@ -118,6 +143,14 @@ in screensaver mode with the clock display set to rebound and the update
 delay set to 1/10th of a second (10 FPS):
 .IP
 $ tty\-clock \-Sra 100000000 \-d 0
+.LP
+Exit after 30 minute have elapsed, showing hours and minutes centered in the window.
+.IP
+$ tty\-clock \-p 1800 \-e \-c
+.LP
+Show a 1 minute and 10 seconds countdown in a box then exit. Hours are hidden, seconds are shown.
+.IP
+$ tty\-clock \-p 70 -x \-Hs
 .LP
 The following example arranges for \fItty\-clock\fR to be displayed
 indefinitely on one of the Virtual Terminals on a Linux system

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -253,6 +253,13 @@ update_clock_layout(void)
 {
      int new_w;
      int y_adj;
+
+     if(!ttyclock.option.date)
+     {
+          wbkgdset(ttyclock.datewin, COLOR_PAIR(0));
+          werase(ttyclock.datewin);
+          wrefresh(ttyclock.datewin);
+     }
  
      new_w = compute_screen_width();
      for(y_adj = 0; (ttyclock.geo.y - y_adj) > (COLS - new_w - 1); ++y_adj);
@@ -418,22 +425,6 @@ clock_rebound(void)
 }
 
 void
-toggle_second(void)
-{
-     ttyclock.option.second = !ttyclock.option.second;
-     update_clock_layout();
-     return;
-}
-
-void
-toggle_hour(void)
-{
-     ttyclock.option.hour = !ttyclock.option.hour;
-     update_clock_layout();
-     return;
-}
-
-void
 set_center(bool b)
 {
      if((ttyclock.option.center = b))
@@ -553,17 +544,25 @@ key_event(void)
 
      case 's':
      case 'S':
-          toggle_second();
+          ttyclock.option.second = !ttyclock.option.second;
+          update_clock_layout();
           break;
 
      case 'm':
      case 'M':
           /* Sad: legacy "move left" is H, so "hour" is M :( */
-          toggle_hour();
+          ttyclock.option.hour = !ttyclock.option.hour;
+          update_clock_layout();
+          break;
 
      case 'e':
      case 'E':
           ttyclock.option.elapsed = !ttyclock.option.elapsed;
+          if(ttyclock.option.elapsed)
+          {
+               ttyclock.option.date = false;
+               update_clock_layout();
+          }
           break;
 
      case 't':
@@ -764,6 +763,7 @@ main(int argc, char **argv)
                break;
           case 'e':
                ttyclock.option.elapsed = true;
+               ttyclock.option.date = false;
                break;
           case 'p':
                if(atol(optarg)>0) {

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -709,11 +709,11 @@ main(int argc, char **argv)
                exit(EXIT_SUCCESS);
                break;
           case 'v':
-               puts("TTY-Clock 2 © devel version");
+               puts("TTY-Clock " VERSIONSTR);
                exit(EXIT_SUCCESS);
                break;
           case 'i':
-               puts("TTY-Clock 2 © by Martin Duquesnoy (xorg62@gmail.com), Grey (grey@greytheory.net)");
+               puts("TTY-Clock " VERSIONSTR " © by Martin Duquesnoy (xorg62@gmail.com), Grey (grey@greytheory.net)");
                exit(EXIT_SUCCESS);
                break;
 

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -555,6 +555,12 @@ key_event(void)
           update_clock_layout();
           break;
 
+     case 'd':
+     case 'D':
+          ttyclock.option.date = !ttyclock.option.date;
+          update_clock_layout();
+          break;
+
      case 'e':
      case 'E':
           ttyclock.option.elapsed = !ttyclock.option.elapsed;

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -37,6 +37,8 @@ void
 init(void)
 {
      struct sigaction sig;
+     setlocale(LC_TIME,"");
+
      ttyclock.bg = COLOR_BLACK;
 
      /* Return codes:

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -397,7 +397,8 @@ set_box(bool b)
           wbkgdset(ttyclock.framewin, COLOR_PAIR(0));
           wbkgdset(ttyclock.datewin, COLOR_PAIR(0));
           box(ttyclock.framewin, 0, 0);
-          box(ttyclock.datewin,  0, 0);
+          if (ttyclock.option.date)
+               box(ttyclock.datewin,  0, 0);
      }
      else {
           wborder(ttyclock.framewin, ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ');
@@ -673,5 +674,6 @@ main(int argc, char **argv)
 
      return 0;
 }
+
 
 // vim: expandtab tabstop=5 softtabstop=5 shiftwidth=5

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -662,92 +662,119 @@ main(int argc, char **argv)
 
      atexit(cleanup);
 
-     while ((c = getopt(argc, argv, "iuvsScbtrhBxnDHC:f:d:T:a:ep:")) != -1)
+     while ((c = getopt(argc, argv, "hvisHDtuf:crd:a:C:Bxbep:SnT:")) != -1)
      {
+          /* "semantically ordered": please keep in sync with this switch, with the tty-clock.1 manpage and README */
+          /* Helper to generate the README: egrep '^ .*[ []-[a-zA-Z].*\\n"' ttyclock.c | sed -e 's/^ *"//' -e 's/\\n".*$//' -e 's/^\s*printf("//' */
           switch(c)
           {
+          /* general information */
           case 'h':
           default:
-               printf("usage : tty-clock [-iuvsScbtrahDHBexne] [-C [0-7]] [-f format] [-d delay] [-a nsdelay] [-p duration] [-T tty] \n"
-                      "    -s            Show seconds                                   \n"
-                      "    -S            Screensaver mode                               \n"
-                      "    -x            Show box                                       \n"
-                      "    -c            Set the clock at the center of the terminal    \n"
-                      "    -C [0-7]      Set the clock color                            \n"
-                      "    -b            Use bold colors                                \n"
-                      "    -t            Set the hour in 12h format                     \n"
-                      "    -u            Use UTC time                                   \n"
-                      "    -T tty        Display the clock on the specified terminal    \n"
-                      "    -r            Do rebound the clock                           \n"
-                      "    -f format     Set the date format                            \n"
-                      "    -n            Don't quit on keypress                         \n"
-                      "    -v            Show tty-clock version                         \n"
-                      "    -i            Show some info about tty-clock                 \n"
-                      "    -h            Show this page                                 \n"
-                      "    -D            Hide date                                      \n"
-                      "    -H            Hide hour                                      \n"
-                      "    -B            Enable blinking colon                          \n"
-                      "    -d delay      Set the delay between two redraws of the clock. Default 1s. \n"
-                      "    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns.\n"
-                      "    -p duration   Set count down duration in seconds. Exit when done.\n"
-                      "    -e            Shows elapsed time.\n");
+               printf("usage : tty-clock [-hvisHDtucrbxBeSn] [-f format] [-d delay] [-a nsdelay] [-C [0-7]] [-p duration] [-T tty]\n"
+                      "    -h            Show this page                                                   \n"
+                      "    -v            Show tty-clock version                                           \n"
+                      "    -i            Show some info about tty-clock                                   \n"
+                      "    -s            Show seconds                                                     \n"
+                      "    -H            Hide hour                                                        \n"
+                      "    -D            Hide date                                                        \n"
+                      "    -t            Set the hour in 12h format                                       \n"
+                      "    -u            Use UTC time                                                     \n"
+                      "    -f format     Set the date format                                              \n"
+                      "    -c            Set the clock at the center of the terminal                      \n"
+                      "    -r            Do rebound the clock                                             \n"
+                      "    -d delay      Set the delay between two redraws of the clock. Default 1s       \n"
+                      "    -a nsdelay    Additional delay between two redraws in nanoseconds. Default 0ns \n"
+                      "    -C [0-7]      Set the clock color                                              \n"
+                      "    -B            Enable blinking colon                                            \n"
+                      "    -x            Show box                                                         \n"
+                      "    -b            Use bold colors                                                  \n"
+                      "    -e            Display elapsed time, not current time                           \n"
+                      "    -p duration   Set count down duration in seconds. Exit when done               \n"
+                      "    -S            Screensaver mode                                                 \n"
+                      "    -n            Don't quit on keypress                                           \n"
+                      "    -T tty        Display the clock on the specified terminal                      \n");
+               exit(EXIT_SUCCESS);
+               break;
+          case 'v':
+               puts("TTY-Clock 2 © devel version");
                exit(EXIT_SUCCESS);
                break;
           case 'i':
                puts("TTY-Clock 2 © by Martin Duquesnoy (xorg62@gmail.com), Grey (grey@greytheory.net)");
                exit(EXIT_SUCCESS);
                break;
-          case 'u':
-               ttyclock.option.utc = true;
-               break;
-          case 'v':
-               puts("TTY-Clock 2 © devel version");
-               exit(EXIT_SUCCESS);
-               break;
+
+          /* shown data */
           case 's':
                ttyclock.option.second = true;
                break;
-          case 'S':
-               ttyclock.option.screensaver = true;
+          case 'H':
+               ttyclock.option.hour = false;
                break;
-          case 'c':
-               ttyclock.option.center = true;
-               break;
-          case 'b':
-               ttyclock.option.bold = true;
-               break;
-          case 'C':
-               if(atoi(optarg) >= 0 && atoi(optarg) < 8)
-                    ttyclock.option.color = atoi(optarg);
+          case 'D':
+               ttyclock.option.date = false;
                break;
           case 't':
                ttyclock.option.twelve = true;
                break;
-          case 'r':
-               ttyclock.option.rebound = true;
+
+          /* data format */
+          case 'u':
+               ttyclock.option.utc = true;
                break;
           case 'f':
                strncpy(ttyclock.option.format, optarg, 100);
+               break;
+
+          /* data layout */
+          case 'c':
+               ttyclock.option.center = true;
+               break;
+          case 'r':
+               ttyclock.option.rebound = true;
                break;
           case 'd':
                if(atol(optarg) >= 0 && atol(optarg) < 100)
                     ttyclock.option.delay = atol(optarg);
                break;
-          case 'D':
-               ttyclock.option.date = false;
-               break;
-          case 'H':
-               ttyclock.option.hour = false;
-               break;
-          case 'B':
-               ttyclock.option.blink = true;
-               break;
           case 'a':
                if(atol(optarg) >= 0 && atol(optarg) < 1000000000)
                     ttyclock.option.nsdelay = atol(optarg);
                break;
+          case 'C':
+               if(atoi(optarg) >= 0 && atoi(optarg) < 8)
+                    ttyclock.option.color = atoi(optarg);
+               break;
+          case 'B':
+               ttyclock.option.blink = true;
+               break;
           case 'x':
                ttyclock.option.box = true;
+               break;
+          case 'b':
+               ttyclock.option.bold = true;
+               break;
+
+          /* special modes */
+          case 'e':
+               ttyclock.option.elapsed = true;
+               ttyclock.option.date = false;
+               break;
+          case 'p':
+               if(atol(optarg)>0) {
+                    ttyclock.option.countdown = true;
+                    ttyclock.option.timeout = atol(optarg);
+                    ttyclock.option.date = false;
+               }
+               break;
+
+          /* screensaver */
+          case 'S':
+               ttyclock.option.screensaver = true;
+               break;
+          case 'n':
+               ttyclock.option.noquit = true;
                break;
           case 'T': {
                struct stat sbuf;
@@ -763,20 +790,6 @@ main(int argc, char **argv)
                     free(ttyclock.tty);
                     ttyclock.tty = strdup(optarg);
                }}
-               break;
-          case 'n':
-               ttyclock.option.noquit = true;
-               break;
-          case 'e':
-               ttyclock.option.elapsed = true;
-               ttyclock.option.date = false;
-               break;
-          case 'p':
-               if(atol(optarg)>0) {
-                    ttyclock.option.countdown = true;
-                    ttyclock.option.timeout = atol(optarg);
-                    ttyclock.option.date = false;
-               }
                break;
           }
      }

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -643,7 +643,7 @@ main(int argc, char **argv)
 
      atexit(cleanup);
 
-     while ((c = getopt(argc, argv, "iuvsScbtrhBxnDC:f:d:T:a:e")) != -1)
+     while ((c = getopt(argc, argv, "iuvsScbtrhBxnDHC:f:d:T:a:e")) != -1)
      {
           switch(c)
           {

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -176,7 +176,7 @@ update_hour(void)
      time_t shown_time;
 
      ttyclock.lt = time(NULL);
-     shown_time = ttyclock.lt;
+     shown_time = (ttyclock.lt_paused ? ttyclock.lt_paused : ttyclock.lt);
 
      if(ttyclock.option.elapsed)
      {
@@ -278,7 +278,7 @@ draw_clock(void)
 {
      int xpos = 1;
      chtype dotcolor = COLOR_PAIR(1);
-     if (ttyclock.option.blink && time(NULL) % 2 == 0)
+     if (ttyclock.option.blink && time(NULL) % 2 == 0 && !ttyclock.lt_paused)
           dotcolor = COLOR_PAIR(2);
 
      /* Draw hour numbers */
@@ -589,6 +589,30 @@ key_event(void)
           init_pair(1, ttyclock.bg, i);
           init_pair(2, i, ttyclock.bg);
           break;
+
+     case 'z':
+     case 'Z':
+          if(ttyclock.lt_origin)
+               ttyclock.lt_origin = ttyclock.lt;
+          if(ttyclock.lt_paused)
+               ttyclock.lt_paused = ttyclock.lt;
+          break;
+
+     case ' ':
+          if(!ttyclock.lt_paused)
+               ttyclock.lt_paused = ttyclock.lt;
+          else
+          {
+               if(ttyclock.lt_origin)
+               {
+                    /* shift origin by the pause duration */
+                    ttyclock.lt_origin += ttyclock.lt - ttyclock.lt_paused;
+                    ttyclock.lt_paused = 0;
+               }
+               ttyclock.lt_paused = 0;
+          }
+          break;
+
 
      default:
           pselect(1, &rfds, NULL, NULL, &length, NULL);

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -50,8 +50,8 @@
 #include <ncurses.h>
 
 /* Macro */
-#define NORMFRAMEW 35
-#define SECFRAMEW  54
+#define FULLFRAMEW 54
+#define CLKFIELDW  19
 #define DATEWINH   3
 #define AMSIGN     " [AM]"
 #define PMSIGN     " [PM]"
@@ -76,6 +76,7 @@ typedef struct
           bool center;
           bool rebound;
           bool date;
+          bool hour;
           bool utc;
           bool box;
           bool noquit;
@@ -119,6 +120,7 @@ typedef struct
 void init(void);
 void signal_handler(int signal);
 void update_hour(void);
+int compute_screen_width(void);
 void draw_number(int n, int x, int y);
 void draw_clock(void);
 void clock_move(int x, int y, int w, int h);

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -86,6 +86,7 @@ typedef struct
           long delay;
           bool blink;
           long nsdelay;
+          bool elapsed;
      } option;
 
      /* Clock geometry */
@@ -108,6 +109,7 @@ typedef struct
      /* time.h utils */
      struct tm *tm;
      time_t lt;
+     time_t lt_origin;
 
      /* Clock member */
      char *meridiem;

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -50,6 +50,7 @@
 #include <ncurses.h>
 
 /* Macro */
+#define VERSIONSTR "2.4dev"
 #define FULLFRAMEW 54
 #define CLKFIELDW  19
 #define DATEWINH   3

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -110,6 +110,7 @@ typedef struct
      struct tm *tm;
      time_t lt;
      time_t lt_origin;
+     time_t lt_paused;
 
      /* Clock member */
      char *meridiem;

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -44,9 +44,9 @@
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <locale.h>
 #include <time.h>
 #include <unistd.h>
-
 #include <ncurses.h>
 
 /* Macro */

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -86,6 +86,8 @@ typedef struct
           long delay;
           bool blink;
           long nsdelay;
+          long timeout;
+          bool countdown;
           bool elapsed;
      } option;
 

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -56,9 +56,15 @@
 #define AMSIGN     " [AM]"
 #define PMSIGN     " [PM]"
 
+/* #define EXIT_SUCESS 0
+ * #define EXIT_FAILURE 1 */
+#define EXIT_INTERRUPTED 2
+
 /* Global ttyclock struct */
 typedef struct
 {
+     int retcode;
+     
      /* while() boolean */
      bool running;
 


### PR DESCRIPTION
`tty-clock` is both good and small, which rocks! Still, I wanted to use it also as a pomodoro timer/countdown ...

It should still be perfectly compatible with your version. There are a few new commands (arguments `-p`, `-e` and options `D`, `E`, `Z`, `space`), a pair of fixes (abusive border with `x` with `-D`, locale #66 ) ... and eventually some non-insignificant cleanup (the manpage, `-h` and `README` are now consistent, and more meaningfully ordered IMHO).

Admittedly, I might have better asked for multiple PR, but I wanted to move forwards today, and I wanted to rewrite my fork so it gets hopefully easier to track for you (I re-ordered the commits for smaller steps and more readability).
Every commit below should be atomic, stable and progressive.

So you have it in one package here. I hope you'll like it (I kept it as small as possible, and that it gets merged in your repo ! :)