### PR TITLE
Fix: "x" command shouldn't toggle date box with -D

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -37,6 +37,8 @@ void
 init(void)
 {
      struct sigaction sig;
+     setlocale(LC_TIME,"");
+
      ttyclock.bg = COLOR_BLACK;
 
      /* Init ncurses */

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -399,7 +399,8 @@ set_box(bool b)
           wbkgdset(ttyclock.framewin, COLOR_PAIR(0));
           wbkgdset(ttyclock.datewin, COLOR_PAIR(0));
           box(ttyclock.framewin, 0, 0);
-          box(ttyclock.datewin,  0, 0);
+          if (ttyclock.option.date)
+               box(ttyclock.datewin,  0, 0);
      }
      else {
           wborder(ttyclock.framewin, ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ');
@@ -675,5 +676,6 @@ main(int argc, char **argv)
 
      return 0;
 }
+
 
 // vim: expandtab tabstop=5 softtabstop=5 shiftwidth=5

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -44,9 +44,9 @@
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <locale.h>
 #include <time.h>
 #include <unistd.h>
-
 #include <ncurses.h>
 
 /* Macro */


### PR DESCRIPTION
Do not show the box around the date with the "x" command key when `tty-clock` was started with `-D` (ie. do not show the date)