### PR TITLE
Makefile: added ttyclock.h in dependencies for building the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #Under BSD License
 #See clock.c for the license detail.
 
-SRC = ttyclock.c
+SRC = ttyclock.c ttyclock.h
 CC ?= gcc
 BIN ?= tty-clock
 PREFIX ?= /usr/local


### PR DESCRIPTION
added `ttyclock.h` in dependencies  for building the binary