### PR TITLE
ttyclock.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -267,7 +267,7 @@ draw_clock(void)
      if (ttyclock.option.date)
      {
           wbkgdset(ttyclock.datewin, (COLOR_PAIR(2)));
-          mvwprintw(ttyclock.datewin, (DATEWINH / 2), 1, ttyclock.date.datestr);
+          mvwprintw(ttyclock.datewin, (DATEWINH / 2), 1, "%s", ttyclock.date.datestr);
           wrefresh(ttyclock.datewin);
      }
 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    ttyclock.c:270:71: error: format not a string literal and no format arguments [-Werror=format-security]
      270 |           mvwprintw(ttyclock.datewin, (DATEWINH / 2), 1, ttyclock.date.datestr);
          |                                                          ~~~~~~~~~~~~~^~~~~~~~

Let's wrap all the missing places with "%s" format.