### PR TITLE
Synchronization

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -705,11 +705,7 @@ time_t rounded_timestamp(void) {
 
      if (clock_gettime(CLOCK_REALTIME, &result) != 0)
      {
-          fprintf(stderr,
-               "Failed to read time from CLOCK_REALTIME - errno: %d, error: %s\n",
-               errno,
-               strerror(errno));
-          exit(1);
+          return time(NULL);
      }
 
     if (result.tv_nsec >= HALF_SECOND_IN_NANOSECONDS)

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -720,8 +720,6 @@ time_t rounded_timestamp(void)
 
 struct timespec sleep_length(void)
 {
-     beep();
-
      static const long SECOND_IN_NANOSECONDS = 1000 * 1000 * 1000;
      static const long NINE_TENTHS = 900 * 1000 * 1000;
 

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -98,7 +98,7 @@ init(void)
      if(ttyclock.option.utc) {
           ttyclock.tm = gmtime(&(ttyclock.lt));
      }
-     ttyclock.lt = time(NULL);
+     ttyclock.lt = timestamp();
      update_hour();
 
      /* Create clock win */
@@ -174,7 +174,7 @@ update_hour(void)
      int ihour;
      char tmpstr[128];
 
-     ttyclock.lt = time(NULL);
+     ttyclock.lt = timestamp();
      ttyclock.tm = localtime(&(ttyclock.lt));
      if(ttyclock.option.utc) {
           ttyclock.tm = gmtime(&(ttyclock.lt));
@@ -256,7 +256,7 @@ draw_clock(void)
      draw_number(ttyclock.date.hour[0], 1, 1);
      draw_number(ttyclock.date.hour[1], 1, 8);
      chtype dotcolor = COLOR_PAIR(1);
-     if (ttyclock.option.blink && time(NULL) % 2 == 0)
+     if (ttyclock.option.blink && timestamp() % 2 == 0)
           dotcolor = COLOR_PAIR(2);
 
      /* 2 dot for number separation */
@@ -425,7 +425,7 @@ key_event(void)
 {
      int i, c;
 
-     struct timespec length = { ttyclock.option.delay, ttyclock.option.nsdelay };
+     struct timespec length = sleep_length();
      
      fd_set rfds;
      FD_ZERO(&rfds);
@@ -684,6 +684,82 @@ main(int argc, char **argv)
      endwin();
 
      return 0;
+}
+
+time_t timestamp(void)
+{
+     if (one_second_delay())
+     {
+          return rounded_timestamp();
+     }
+     else
+     {
+          return time(NULL);
+     }
+}
+
+time_t rounded_timestamp(void)
+{
+     static const long HALF_SECOND_IN_NANOSECONDS = 500 * 1000 * 1000;
+     struct timespec currentTime;
+
+     if (clock_gettime(CLOCK_REALTIME, &currentTime) != 0)
+     {
+          return time(NULL);
+     }
+
+     if (currentTime.tv_nsec >= HALF_SECOND_IN_NANOSECONDS)
+     {
+          return currentTime.tv_sec + 1;
+     }
+     else
+     {
+          return currentTime.tv_sec;
+     }
+}
+
+struct timespec sleep_length(void)
+{
+     static const long SECOND_IN_NANOSECONDS = 1000 * 1000 * 1000;
+     static const long NINE_TENTHS = 900 * 1000 * 1000;
+
+     if (one_second_delay())
+     {
+          struct timespec currentTime;
+
+          if (clock_gettime(CLOCK_REALTIME, &currentTime) == 0 &&
+               currentTime.tv_nsec > 0)
+          {
+               struct timespec result;
+
+               if (currentTime.tv_nsec < NINE_TENTHS) {
+                    result.tv_sec = ttyclock.option.delay - 1;
+               }
+               else
+               {
+                    result.tv_sec = ttyclock.option.delay;
+               }
+
+               result.tv_nsec = SECOND_IN_NANOSECONDS - currentTime.tv_nsec;
+               return result;
+          }
+     }
+
+     return simple_sleep_length();
+}
+
+struct timespec simple_sleep_length(void)
+{
+     struct timespec result;
+     result.tv_sec = ttyclock.option.delay;
+     result.tv_nsec = ttyclock.option.nsdelay;
+     return result;
+}
+
+bool one_second_delay(void)
+{
+     return ttyclock.option.delay == 1 &&
+          ttyclock.option.nsdelay == 0;
 }
 
 // vim: expandtab tabstop=5 softtabstop=5 shiftwidth=5

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -113,7 +113,6 @@ typedef struct
      char *meridiem;
      WINDOW *framewin;
      WINDOW *datewin;
-
 } ttyclock_t;
 
 /* Prototypes */
@@ -127,6 +126,11 @@ void set_second(void);
 void set_center(bool b);
 void set_box(bool b);
 void key_event(void);
+time_t timestamp(void);
+time_t rounded_timestamp(void);
+struct timespec sleep_length(void);
+struct timespec simple_sleep_length(void);
+bool one_second_delay(void);
 
 /* Global variable */
 ttyclock_t ttyclock;

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -85,6 +85,7 @@ typedef struct
           long delay;
           bool blink;
           long nsdelay;
+          bool rounding_to_closest_second;
      } option;
 
      /* Clock geometry */
@@ -113,7 +114,6 @@ typedef struct
      char *meridiem;
      WINDOW *framewin;
      WINDOW *datewin;
-
 } ttyclock_t;
 
 /* Prototypes */
@@ -127,6 +127,8 @@ void set_second(void);
 void set_center(bool b);
 void set_box(bool b);
 void key_event(void);
+time_t timestamp(void);
+time_t rounded_timestamp(void);
 
 /* Global variable */
 ttyclock_t ttyclock;

--- a/ttyclock.h
+++ b/ttyclock.h
@@ -85,7 +85,6 @@ typedef struct
           long delay;
           bool blink;
           long nsdelay;
-          bool rounding_to_closest_second;
      } option;
 
      /* Clock geometry */
@@ -129,6 +128,9 @@ void set_box(bool b);
 void key_event(void);
 time_t timestamp(void);
 time_t rounded_timestamp(void);
+struct timespec sleep_length(void);
+struct timespec simple_sleep_length(void);
+bool one_second_delay(void);
 
 /* Global variable */
 ttyclock_t ttyclock;


### PR DESCRIPTION
Synchronization with second change when delay is one second and nsdelay is zero.

When displaying time under these circumstances, a timestamp rounded to the closest second is used.