### PR TITLE
Second change synchronization

### DIFF
--- a/ttyclock.h
+++ b/ttyclock.h
@@ -127,6 +127,11 @@ void set_second(void);
 void set_center(bool b);
 void set_box(bool b);
 void key_event(void);
+time_t timestamp(void);
+time_t rounded_timestamp(void);
+struct timespec sleep_length(void);
+struct timespec simple_sleep_length(void);
+bool whole_seconds_delay(void);
 
 /* Global variable */
 ttyclock_t ttyclock;


### PR DESCRIPTION
Synchronization with second change when delay is one second and nsdelay is zero.

When displaying time under these circumstances, a timestamp rounded to the closest second is used.