### PR TITLE
Separated SOURCE and HEADER from SRC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 #Under BSD License
 #See clock.c for the license detail.
 
-SRC = ttyclock.c ttyclock.h
+SOURCE = ttyclock.c
+HEADER = ttyclock.h
 CC ?= gcc
 BIN ?= tty-clock
 PREFIX ?= /usr/local
@@ -26,10 +27,10 @@ else
 	LDFLAGS += $$(pkg-config --libs ncurses)
 endif
 
-tty-clock : ${SRC}
+tty-clock : ${SOURCE} ${HEADER}
 
-	@echo "building ${SRC}"
-	${CC} ${CFLAGS} ${SRC} -o ${BIN} ${LDFLAGS}
+	@echo "building ${SOURCE}"
+	${CC} ${CFLAGS} ${SOURCE} -o ${BIN} ${LDFLAGS}
 
 install : ${BIN}
 


### PR DESCRIPTION
Prior to this change, a variable SRC was used, including ttyclock.c and ttyclock.h, for both dependencies and the C compiler call.

This led to incompatibilities with stricter C compiler, like clang.