### PR TITLE
Adds Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tty-clock
+tty-clock.dSYM/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ADD . /src
 RUN make
 
 FROM docker.io/alpine:3.15
-RUN apk add -U ncurses-libs
+ARG TIMEZONE=UTC
 COPY --from=0 /src/tty-clock /usr/bin/tty-clock
 CMD ['/usr/bin/tty-clock']
+RUN apk add -U ncurses-libs tzdata && \
+    cp -rf /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/alpine:3.15
+RUN apk add -U build-base ncurses-dev
+WORKDIR /src
+ADD . /src
+RUN make
+
+FROM alpine
+RUN apk add -U ncurses-libs
+COPY --from=0 /src/tty-clock /usr/bin/tty-clock
+CMD ['/usr/bin/tty-clock']

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 ADD . /src
 RUN make
 
-FROM alpine
+FROM docker.io/alpine:3.15
 RUN apk add -U ncurses-libs
 COPY --from=0 /src/tty-clock /usr/bin/tty-clock
 CMD ['/usr/bin/tty-clock']

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BIN ?= tty-clock
 PREFIX ?= /usr/local
 INSTALLPATH ?= ${DESTDIR}${PREFIX}/bin
 MANPATH ?= ${DESTDIR}${PREFIX}/share/man/man1
+DOCKER ?= docker
 
 ifeq ($(shell sh -c 'which ncurses6-config>/dev/null 2>/dev/null && echo y'), y)
 	CFLAGS += -Wall -g $$(ncurses6-config --cflags)
@@ -57,3 +58,7 @@ clean :
 	@rm -f ${BIN}
 	@echo "${BIN} cleaned"
 
+docker :
+
+	${DOCKER} build -t localhost/tty-clock .
+	@echo "Run the container: ${DOCKER} run --rm -it localhost/tty-clock tty-clock --help"

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ clean :
 docker :
 
 	${DOCKER} build --build-arg=TIMEZONE=${DOCKER_TIMEZONE} -t ${DOCKER_IMAGE} .
-	@echo "Run the container: ${DOCKER} run --rm -it ${DOCKER_IMAGE} tty-clock --help"
+	@echo "Run the container: ${DOCKER} run --rm -it  -e TZ=${DOCKER_TIMEZONE} ${DOCKER_IMAGE} tty-clock --help"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PREFIX ?= /usr/local
 INSTALLPATH ?= ${DESTDIR}${PREFIX}/bin
 MANPATH ?= ${DESTDIR}${PREFIX}/share/man/man1
 DOCKER ?= docker
+DOCKER_IMAGE ?= localhost/tty-clock
 
 ifeq ($(shell sh -c 'which ncurses6-config>/dev/null 2>/dev/null && echo y'), y)
 	CFLAGS += -Wall -g $$(ncurses6-config --cflags)
@@ -60,5 +61,5 @@ clean :
 
 docker :
 
-	${DOCKER} build -t localhost/tty-clock .
-	@echo "Run the container: ${DOCKER} run --rm -it localhost/tty-clock tty-clock --help"
+	${DOCKER} build -t ${DOCKER_IMAGE} .
+	@echo "Run the container: ${DOCKER} run --rm -it ${DOCKER_IMAGE} tty-clock --help"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INSTALLPATH ?= ${DESTDIR}${PREFIX}/bin
 MANPATH ?= ${DESTDIR}${PREFIX}/share/man/man1
 DOCKER ?= docker
 DOCKER_IMAGE ?= localhost/tty-clock
+DOCKER_TIMEZONE ?= UTC
 
 ifeq ($(shell sh -c 'which ncurses6-config>/dev/null 2>/dev/null && echo y'), y)
 	CFLAGS += -Wall -g $$(ncurses6-config --cflags)
@@ -61,5 +62,5 @@ clean :
 
 docker :
 
-	${DOCKER} build -t ${DOCKER_IMAGE} .
+	${DOCKER} build --build-arg=TIMEZONE=${DOCKER_TIMEZONE} -t ${DOCKER_IMAGE} .
 	@echo "Run the container: ${DOCKER} run --rm -it ${DOCKER_IMAGE} tty-clock --help"


### PR DESCRIPTION
This adds a `Dockerfile` and a `make docker` target to build tty-clock in an alpine container image.

With the Dockerfile colocated with the source code in git, you can build the image all with one command:

```
## Build using my fork (replace /xorg62 if merged):
docker build https://github.com/EnigmaCurry/tty-clock.git#master -t localhost/tty-clock

## To run the image:
docker run --rm -it localhost/tty-clock tty-clock -u -c -s -C 3 -b
```
