### PR TITLE
Fix issue #106, to make it work on a real DEC VT320

### DIFF
--- a/ttyclock.c
+++ b/ttyclock.c
@@ -220,6 +220,18 @@ draw_number(int n, int x, int y)
      int i, sy = y;
      unsigned int pixel_on  = COLOR_PAIR(2) | A_REVERSE;
      unsigned int pixel_off = COLOR_PAIR(0) | A_NORMAL;
+     /*
+      * pixel_on is a bitmask made by:
+      * - COLOR_PAIR(2), defined by "init_color"
+      * - A_REVERSE is the attribute that defines reverse characters (reversed space is a big "pixel")
+      *
+      * pixel_off is anothter bitmask made by:
+      * - COLOR_PAIR(0) which means "not visible"
+      * A_NORMAL is "not reverse" attribute
+      *
+      * so "pixel_on" is used to draw "block characters" which are reversed spaces,
+      *    "pixel_off" is used to draw the "empty space".
+      */
 
      for(i = 0; i < 30; ++i, ++sy)
      {

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -218,6 +218,8 @@ void
 draw_number(int n, int x, int y)
 {
      int i, sy = y;
+     unsigned int on  = COLOR_PAIR(2) | A_REVERSE;
+     unsigned int off = COLOR_PAIR(0) | A_NORMAL;
 
      for(i = 0; i < 30; ++i, ++sy)
      {
@@ -233,8 +235,8 @@ draw_number(int n, int x, int y)
                wattroff(ttyclock.framewin, A_BLINK);
 
           wbkgdset(ttyclock.framewin, number[n][i/2]
-               ? COLOR_PAIR(2) | A_REVERSE
-               : COLOR_PAIR(0) | A_NORMAL
+               ? on
+               : off
           );
           mvwaddch(ttyclock.framewin, x, sy, ' ');
      }

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -70,9 +70,6 @@ init(void)
      init_pair(0, ttyclock.bg, ttyclock.bg);
      init_pair(1, ttyclock.bg, ttyclock.option.color);
      init_pair(2, ttyclock.option.color, ttyclock.bg);
-//     init_pair(0, ttyclock.bg, ttyclock.bg);
-//     init_pair(1, ttyclock.bg, ttyclock.option.color);
-//     init_pair(2, ttyclock.option.color, ttyclock.bg);
      refresh();
 
      /* Init signal handler */
@@ -162,6 +159,7 @@ signal_handler(int signal)
 void
 cleanup(void)
 {
+     /* Turn on cursor on VT100 compatible terminals */
      printf("\033[?25h");
 
      if (ttyclock.ttyscr)
@@ -234,9 +232,9 @@ draw_number(int n, int x, int y)
           else
                wattroff(ttyclock.framewin, A_BLINK);
 
-          wbkgdset(ttyclock.framewin, COLOR_PAIR(number[n][i/2])
-               ? 2*COLOR_PAIR(number[n][i/2]) | A_REVERSE
-               : 2*COLOR_PAIR(number[n][i/2]) | A_NORMAL
+          wbkgdset(ttyclock.framewin, number[n][i/2]
+               ? COLOR_PAIR(2) | A_REVERSE
+               : COLOR_PAIR(0) | A_NORMAL
           );
           mvwaddch(ttyclock.framewin, x, sy, ' ');
      }
@@ -292,7 +290,6 @@ draw_clock(void)
      {
           /* Again 2 dot for number separation */
           wbkgdset(ttyclock.framewin, dotcolor | A_REVERSE);
-
           mvwaddstr(ttyclock.framewin, 2, NORMFRAMEW, "  ");
           mvwaddstr(ttyclock.framewin, 4, NORMFRAMEW, "  ");
           wbkgdset(ttyclock.framewin, dotcolor | A_NORMAL);
@@ -335,6 +332,7 @@ clock_move(int x, int y, int w, int h)
                 ttyclock.geo.y + (ttyclock.geo.w / 2) - (strlen(ttyclock.date.datestr) / 2) - 1);
           wresize(ttyclock.datewin, DATEWINH, strlen(ttyclock.date.datestr) + 2);
 
+          /* Draw "T" box-drawing character for joining clock and date windows */
           if (ttyclock.option.box) {
                box(ttyclock.datewin,  0, 0);
                mvwaddch(ttyclock.datewin, 0, 0, ACS_TTEE);
@@ -420,7 +418,6 @@ set_box(bool b)
           wbkgdset(ttyclock.datewin, COLOR_PAIR(0));
           box(ttyclock.framewin, 0, 0);
           box(ttyclock.datewin,  0, 0);
-
      }
      else {
           wborder(ttyclock.framewin, ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ');
@@ -430,6 +427,7 @@ set_box(bool b)
      wrefresh(ttyclock.datewin);
      wrefresh(ttyclock.framewin);
 
+     /* Draw "T" box-drawing character for joining clock and date windows */
      if(ttyclock.option.box) {
           mvwaddch(ttyclock.datewin, 0, 0, ACS_TTEE);
           mvwaddch(ttyclock.datewin, 0, strlen(ttyclock.date.datestr) + 1, ACS_TTEE);
@@ -569,6 +567,7 @@ main(int argc, char **argv)
 {
      int c;
 
+     /* Turn off cursor on VT100 compatible terminals */
      printf("\033[?25l");
 
      /* Alloc ttyclock */

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -218,8 +218,8 @@ void
 draw_number(int n, int x, int y)
 {
      int i, sy = y;
-     unsigned int on  = COLOR_PAIR(2) | A_REVERSE;
-     unsigned int off = COLOR_PAIR(0) | A_NORMAL;
+     unsigned int pixel_on  = COLOR_PAIR(2) | A_REVERSE;
+     unsigned int pixel_off = COLOR_PAIR(0) | A_NORMAL;
 
      for(i = 0; i < 30; ++i, ++sy)
      {
@@ -235,8 +235,8 @@ draw_number(int n, int x, int y)
                wattroff(ttyclock.framewin, A_BLINK);
 
           wbkgdset(ttyclock.framewin, number[n][i/2]
-               ? on
-               : off
+               ? pixel_on
+               : pixel_off
           );
           mvwaddch(ttyclock.framewin, x, sy, ' ');
      }

--- a/ttyclock.c
+++ b/ttyclock.c
@@ -227,7 +227,7 @@ draw_number(int n, int x, int y)
       *
       * pixel_off is anothter bitmask made by:
       * - COLOR_PAIR(0) which means "not visible"
-      * A_NORMAL is "not reverse" attribute
+      * - A_NORMAL is "not reverse" attribute
       *
       * so "pixel_on" is used to draw "block characters" which are reversed spaces,
       *    "pixel_off" is used to draw the "empty space".


### PR DESCRIPTION
Fix issue https://github.com/xorg62/tty-clock/issues/106

- Using A_REVERSE attribute (a reversed space), now the digit are visible also on a real hardware DEC VT320
- The blinking cursor is hidden at the start, and is re-enabled at the end of the execution. I used printf() with ANSI code because ncurses "curs_set" function did not work on the real hardware
- The small "glitches" of the date's window are now fixed throw 2 "box-drawing characters" (ACS_TTEE)
![image](https://user-images.githubusercontent.com/2118813/152182802-9172342c-5430-45f4-8b9c-9ba5a480e016.png)
